### PR TITLE
Add dependabot and release-drafter Github Action

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,8 @@
+version: 1
+update_configs:
+  - package_manager: "docker"
+    directory: /
+    update_schedule: "weekly"
+    target_branch: "master"
+    default_reviewers:
+      - "sharu1204"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,18 @@
+name-template: "v$NEXT_PATCH_VERSION"
+tag-template: "v$NEXT_PATCH_VERSION"
+categories:
+  - title: "New Features"
+    label: feature
+  - title: "Fixed Issues"
+    label: bug
+  - title: "Refactor"
+    label: refactor
+  - title: "Dependencies"
+    label: dependencies
+  - title: "Documentation"
+    label: documentation
+
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+template: |
+  ## Changes
+  $CHANGES

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -1,0 +1,15 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    name: Update release draft
+    steps:
+      - uses: release-drafter/release-drafter@v5.9.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We've gotta add `release-drafter` Github Action to prepare release drafts. @taizo 🙏 