### PR TITLE
Make unofficial providers eligible for updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ If you want to skip the current latest version for some reason, you can simply c
 
 **Optional** The name of provider. _Required_ when setting `"provider"` resource.
 
+### `provider_repo`
+
+**Optional** GitHub repository of provider. _Required_ when using [Verified/Community providers](https://registry.terraform.io/browse/providers?tier=partner%2Ccommunity).
+
 ### `module_name`
 
 **Optional** The name of module. _Required_ when setting `"module"` resource.

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
   provider_name:
     description: "Provider name to be updated"
     required: false
+  provider_repo:
+    description: "Provider GitHub repository to be updated"
+    required: false
   module_name:
     description: "Module name to be updated"
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,8 +19,12 @@ function run_tfupdate {
         echo 'ERROR: "provier_name" needs to be set for "provider" resource'
         exit 1
       fi
-      VERSION=$(tfupdate release latest terraform-providers/terraform-provider-${INPUT_PROVIDER_NAME})
-      PULL_REQUEST_BODY="For details see: https://github.com/terraform-providers/terraform-provider-${INPUT_PROVIDER_NAME}/releases"
+      REPOSITORY="terraform-providers/terraform-provider-${INPUT_PROVIDER_NAME}"
+      if [ -n "${INPUT_PROVIDER_REPO}" ]; then
+        REPOSITORY=${INPUT_PROVIDER_REPO}
+      fi
+      VERSION=$(tfupdate release latest "$REPOSITORY")
+      PULL_REQUEST_BODY="For details see: https://github.com/$REPOSITORY/releases"
       UPDATE_MESSAGE="[tfupdate] Bump Terraform Provider ${INPUT_PROVIDER_NAME} to v${VERSION}"
       ;;
     module)


### PR DESCRIPTION
There are many providers in Terraform.
https://registry.terraform.io/browse/providers

There are 3 tiers in Terraform providers: Official, Verified, Community.

Official providers have a fixed prefix: `hashicorp/`. But Verified/Community providers have an arbitrary prefix.

So in this PR, I added a new parameter: `provider_repo`.
If you use GitHub Provider, specify as follows:

```yaml
      - name: Update github provider
        uses: HENNGE/tfupdate-action@v1.0.2
        with:
          resource: "provider"
          provider_name: "github"
          provider_repo: "integrations/terraform-provider-github"
```
