### PR TITLE
Use exact match when checking PR title

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,13 +75,13 @@ function run_tfupdate {
   git config --local user.name "${USER_NAME}"
 
   # Checkout a branch if a PR does not exist.
-  if hub pr list -s "open" -f "%t: %U%n" | grep -F "${UPDATE_MESSAGE}"; then
+  if hub pr list -s "open" -f "%t%n" | grep -Fx "${UPDATE_MESSAGE}"; then
     echo "A pull request already exists"
     exit 0
-  elif hub pr list -s "merged" -f "%t: %U%n" | grep -F "${UPDATE_MESSAGE}"; then
+  elif hub pr list -s "merged" -f "%t%n" | grep -Fx "${UPDATE_MESSAGE}"; then
     echo "A pull request is already merged"
     exit 0
-  elif hub pr list -s "closed" -f "%t: %U%n" | grep -F "${UPDATE_MESSAGE}"; then
+  elif hub pr list -s "closed" -f "%t%n" | grep -Fx "${UPDATE_MESSAGE}"; then
     echo "A pull request is already closed"
     exit 0
   else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,9 @@ function run_tfupdate {
     terraform)
       VERSION=$(tfupdate release latest hashicorp/terraform)
       PULL_REQUEST_BODY="For details see: https://github.com/hashicorp/terraform/releases"
+      # Changing UPDATE_MESSAGE variable will cause issue in matching existing pull requests
+      # Do not change unless absolutely necessary
+      # ref. https://github.com/HENNGE/tfupdate-action/issues/25
       UPDATE_MESSAGE="[tfupdate] Bump Terraform to v${VERSION}"
       ;;
   
@@ -25,6 +28,9 @@ function run_tfupdate {
       fi
       VERSION=$(tfupdate release latest "$REPOSITORY")
       PULL_REQUEST_BODY="For details see: https://github.com/$REPOSITORY/releases"
+      # Changing UPDATE_MESSAGE variable will cause issue in matching existing pull requests
+      # Do not change unless absolutely necessary
+      # ref. https://github.com/HENNGE/tfupdate-action/issues/25
       UPDATE_MESSAGE="[tfupdate] Bump Terraform Provider ${INPUT_PROVIDER_NAME} to v${VERSION}"
       ;;
     module)
@@ -33,6 +39,9 @@ function run_tfupdate {
         exit 1
       fi
       VERSION=$(tfupdate release latest --source-type=${INPUT_SOURCE_TYPE} ${INPUT_MODULE_NAME})
+      # Changing UPDATE_MESSAGE variable will cause issue in matching existing pull requests
+      # Do not change unless absolutely necessary
+      # ref. https://github.com/HENNGE/tfupdate-action/issues/25
       UPDATE_MESSAGE="[tfupdate] Bump Terraform Module ${INPUT_MODULE_NAME} to v${VERSION}"
       case ${INPUT_SOURCE_TYPE} in
         github)


### PR DESCRIPTION
Proposed fix for #25 

`hub pr list` will only output the list of PR title. 
This way we can use `grep -Fx` to find lines that is exact match with the `UPDATE_MESSAGE`
The downside is that the link to PR will not be shown on the output anymore