### PR TITLE
Fix possible race condition of push and PR creation

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -113,9 +113,9 @@ function run_tfupdate {
     echo "Creating a pull request: ${UPDATE_MESSAGE}"
     git commit -m "${UPDATE_MESSAGE}"
     if [ ${INPUT_REVIEWER} ]; then
-      git push origin HEAD && hub pull-request -m "${UPDATE_MESSAGE}" -m "${PULL_REQUEST_BODY}" -b "${INPUT_BASE_BRANCH}" -l "${INPUT_LABEL}" -r "${INPUT_REVIEWER}"
+      hub pull-request -m "${UPDATE_MESSAGE}" -m "${PULL_REQUEST_BODY}" -b "${INPUT_BASE_BRANCH}" -l "${INPUT_LABEL}" -r "${INPUT_REVIEWER}" -p
     else
-      git push origin HEAD && hub pull-request -m "${UPDATE_MESSAGE}" -m "${PULL_REQUEST_BODY}" -b "${INPUT_BASE_BRANCH}" -l "${INPUT_LABEL}"
+      hub pull-request -m "${UPDATE_MESSAGE}" -m "${PULL_REQUEST_BODY}" -b "${INPUT_BASE_BRANCH}" -l "${INPUT_LABEL}" -p
     fi
   fi
 }


### PR DESCRIPTION
It's possible for the PR creation to fail due to new push/branch not finished creating on github.
It happens in sugoadmin https://github.com/HENNGE/sugoadmin/pull/1356, with the error message suggesting that the new branch is not found yet on remote. See related issue here https://github.com/github/hub/issues/1258.

This will use hub's `--push` functionality to do the push, which is capable of retrying on said error (defaults to 9 times).
https://hub.github.com/hub-pull-request.1.html#:~:text=CONFIGURATION-,HUB_RETRY_TIMEOUT,-The%20maximum%20time

