### PR TITLE
Support multiple PRs for same version in same repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ If you want to skip the current latest version for some reason, you can simply c
 
 **Optional** A reviewer to be assigned to a PR. You can assign multiple reviewers with a comma-separated list (no spaces around the comma).
 
+### `branch_name_suffix`
+
+**Optional** A suffix to append the branch name. This will allow multiple PRs in the same repo, for different paths or CODEOWNERS, for example.
+
 ## Example Usage
 
 ```yml

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,9 @@ inputs:
   reviewer:
     description: "Reviewer to be assigned when creating a PR"
     required: false
+  branch_name_suffix:
+    description: "Suffix branch name with given string. Allows multiple update PRs in same repo"
+    required: false
 
 runs:
   using: "docker"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -91,13 +91,13 @@ function run_tfupdate {
   if [ -n "${INPUT_BRANCH_NAME_SUFFIX}" ]; then
     BRANCH_NAME="${BRANCH_NAME}_${INPUT_BRANCH_NAME_SUFFIX}"
   fi
-  if hub pr list -s "open" -h "${BRANCH_NAME}"; then
+  if [[ $(hub pr list -s "open" -h "${BRANCH_NAME}") ]]; then
     echo "A pull request already exists"
     exit 0
-  elif hub pr list -s "merged" -h "${BRANCH_NAME}"; then
+  elif [[ $(hub pr list -s "merged" -h "${BRANCH_NAME}") ]]; then
     echo "A pull request is already merged"
     exit 0
-  elif hub pr list -s "closed" -h "${BRANCH_NAME}"; then
+  elif [[ $(hub pr list -s "closed" -h "${BRANCH_NAME}") ]]; then
     echo "A pull request is already closed"
     exit 0
   else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -87,17 +87,17 @@ function run_tfupdate {
   git config --local user.name "${USER_NAME}"
 
   # Checkout a branch if a PR does not exist.
-  BRANCH_NAME=$(echo "$UPDATE_MESSAGE" | sed "s/\./\\\./g; s/\]/\\\]/g; s/\[/\\\[/g")
+  BRANCH_NAME="update-${INPUT_RESOURCE}-to-v${VERSION}"
   if [ -n "${INPUT_BRANCH_NAME_SUFFIX}" ]; then
     BRANCH_NAME="${BRANCH_NAME}_${INPUT_BRANCH_NAME_SUFFIX}"
   fi
-  if hub pr list -s "open" -f "%t: %U%n" | grep -x "${BRANCH_NAME}:.*"; then
+  if hub pr list -s "open" -h "${BRANCH_NAME}"; then
     echo "A pull request already exists"
     exit 0
-  elif hub pr list -s "merged" -f "%t: %U%n" | grep -x "${BRANCH_NAME}:.*"; then
+  elif hub pr list -s "merged" -h "${BRANCH_NAME}"; then
     echo "A pull request is already merged"
     exit 0
-  elif hub pr list -s "closed" -f "%t: %U%n" | grep -x "${BRANCH_NAME}:.*"; then
+  elif hub pr list -s "closed" -h "${BRANCH_NAME}"; then
     echo "A pull request is already closed"
     exit 0
   else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,7 @@ function run_tfupdate {
       # ref. https://github.com/HENNGE/tfupdate-action/issues/25
       UPDATE_MESSAGE="[tfupdate] Bump Terraform to v${VERSION}"
       ;;
-  
+
     provider)
       if [ ! ${INPUT_PROVIDER_NAME} ]; then
         echo 'ERROR: "provier_name" needs to be set for "provider" resource'
@@ -87,21 +87,23 @@ function run_tfupdate {
   git config --local user.name "${USER_NAME}"
 
   # Checkout a branch if a PR does not exist.
-  ESCAPED_MESSAGE=$(echo $UPDATE_MESSAGE | sed "s/\./\\\./g; s/\]/\\\]/g; s/\[/\\\[/g")
-  if hub pr list -s "open" -f "%t: %U%n" | grep -x "${ESCAPED_MESSAGE}:.*"; then
+  BRANCH_NAME=$(echo "$UPDATE_MESSAGE" | sed "s/\./\\\./g; s/\]/\\\]/g; s/\[/\\\[/g")
+  if [ -n "${INPUT_BRANCH_NAME_SUFFIX}" ]; then
+    BRANCH_NAME="${BRANCH_NAME}_${INPUT_BRANCH_NAME_SUFFIX}"
+  fi
+  if hub pr list -s "open" -f "%t: %U%n" | grep -x "${BRANCH_NAME}:.*"; then
     echo "A pull request already exists"
     exit 0
-  elif hub pr list -s "merged" -f "%t: %U%n" | grep -x "${ESCAPED_MESSAGE}:.*"; then
+  elif hub pr list -s "merged" -f "%t: %U%n" | grep -x "${BRANCH_NAME}:.*"; then
     echo "A pull request is already merged"
     exit 0
-  elif hub pr list -s "closed" -f "%t: %U%n" | grep -x "${ESCAPED_MESSAGE}:.*"; then
+  elif hub pr list -s "closed" -f "%t: %U%n" | grep -x "${BRANCH_NAME}:.*"; then
     echo "A pull request is already closed"
     exit 0
   else
-    CHECKOUT_BRANCH="update-${INPUT_RESOURCE}-to-v${VERSION}"
-    echo "Checking out to ${CHECKOUT_BRANCH} branch"
+    echo "Checking out to ${BRANCH_NAME} branch"
     git fetch --all
-    git checkout -b ${CHECKOUT_BRANCH} origin/${INPUT_BASE_BRANCH}
+    git checkout -b "${BRANCH_NAME}" "origin/${INPUT_BASE_BRANCH}"
   fi
 
   # Execute tfupdate command


### PR DESCRIPTION
In larger IaC repos, having a single mega-bump-PR across all terraform states is not always suitable. There may be many stakeholders and different CODEOWNERS, or one broken terraform state where a failing workflow check is blocking all others.

The action supports paths and excluding paths, but this does not play with the checks for existing PR. By supplying an optional branch name suffix we can solve this problem and allow multiple PRs for the same version in the same repository.