### PR TITLE
Update the default repository path for providers

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@ function run_tfupdate {
         echo 'ERROR: "provier_name" needs to be set for "provider" resource'
         exit 1
       fi
-      REPOSITORY="terraform-providers/terraform-provider-${INPUT_PROVIDER_NAME}"
+      REPOSITORY="hashicorp/terraform-provider-${INPUT_PROVIDER_NAME}"
       if [ -n "${INPUT_PROVIDER_REPO}" ]; then
         REPOSITORY=${INPUT_PROVIDER_REPO}
       fi


### PR DESCRIPTION
The terraform-providers organization has been archived. 
Pointing to certain provider repositories it contains (or used to contain) will automatically redirect to their new location under the hashicorp organization. 
Some providers however will give a 404 (e.g. https://github.com/terraform-providers/terraform-provider-time). 
The hashicorp organization seems to be the current home for all hashicorp providers so the default path should be changed accordingly.